### PR TITLE
Move config.report_api_key to serverconfig._gemini_api_key

### DIFF
--- a/backend/app/asm/proc_report.py
+++ b/backend/app/asm/proc_report.py
@@ -21,7 +21,7 @@ class ProcReport:
 
 	def review_description(self, description):
 		# print(f"description: {description}")
-		API_KEY = self.__context.config.report_api_key
+		API_KEY = self.__context.session.server_config._gemini_api_key
 		END_POINT = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key={API_KEY}"
 		custom_txt = """
 		依頼: CVEの説明を下記に記載するので、日本語で脆弱性評価をしてください。

--- a/backend/app/schemes/config.py
+++ b/backend/app/schemes/config.py
@@ -26,7 +26,6 @@ class ConfigModel(BaseModel):
 	report_min_cvss3: float = Field(7.0, description="レポートする最小のCVSS3スコア(しきい値)")
 	report_csv_encoding: str = Field("utf-8", description="レポートのCSVファイルの文字エンコーディング。設定値はそのままPythonの`open()`の`encoding`に渡される。そのためBOM付きUTF-8にしたい場合は`utf-8-sig`を指定する")
 	report_enable_gemini: bool = Field(False, description="Geminiによる分析を使用するか")
-	report_api_key: str = Field("", description="レポートに使うGemini Pro APIのキー")
 	report_enable_bcc: bool = Field(False, description="CCの代わりにBCCを使うか")
 	report_from: str = Field("", description="レポートのFromとして使うEメールアドレス")
 

--- a/backend/app/schemes/serverconfig.py
+++ b/backend/app/schemes/serverconfig.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 class ServerConfigModel(BaseModel):
 	"""サーバーの設定。ユーザー(クライアント)は変更できない"""
 
-	cveapi_base: str = Field("https://cvepremium.circl.lu/api", description="CIRCL CVE Search APIのプロトコルとホスト名を含むベースURL")
-	version: str = Field("0.1.0", description="このASMツールサーバーのバージョン")
+	# パブリック。クライアントから見えても問題ないもの
+	cveapi_base: str = Field(default="https://cvepremium.circl.lu/api", description="CIRCL CVE Search APIのプロトコルとホスト名を含むベースURL")
+	version: str = Field(default="0.1.0", description="このASMツールサーバーのバージョン")
+
+	# プライベート。隠蔽したいもの
+	_gemini_api_key: str = PrivateAttr("")
+	"""Gemini ProのAPIキー"""

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -23,7 +23,7 @@ class Session():
 	def __init__(self, config: ConfigModel):
 		self.__uuid = uuid4()
 		self.__conf = config
-		self.__server_conf = ServerConfigModel(version="0.1.0", cveapi_base="https://cvepremium.circl.lu/api")
+		self.__server_conf = ServerConfigModel()
 		self.__workdir = Path("work", str(self.__uuid))
 		self.__workdir.mkdir(parents=True, exist_ok=False)
 		self.__logger = Logger(filepath=str(self.__workdir / "log.txt"), user_config=self.__conf)


### PR DESCRIPTION
Gemini ProのAPIキーを今まではクライアントから`report_api_key`という名で受け付けていた
それをサーバー側でプライベートな、つまりクライアントからは隠蔽された設定として保持するように変えた

`/session/create`のレスポンスの一部。このレスポンスの`server_config`内に`_gemini_api_key`は含まれていないのが確認できる
つまりクライアントからは隠蔽されとる
![/session/createのレスポンスの一部。_gemini_api_keyは含まれていない](https://github.com/user-attachments/assets/f5460325-e5e9-4802-af08-d61c1036f7f3)

今までどおりクライアントからGemini ProのAPIキーを提供してもらう方式のままにしたいならマージはしないでcloseする感じで