### PR TITLE
/result/showで出力する情報の追加

### DIFF
--- a/backend/app/routers/result.py
+++ b/backend/app/routers/result.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends
 
 from routers.session import ensure_session
 from schemes.result import (
+	HostCpePortsModel,
 	ResultCveModel,
 	ResultModel,
 	ResultNmapModel,
@@ -49,7 +50,12 @@ def show(
 		except: pass
 
 	if session.config.search_cve:
-		try: r.cve = ResultCveModel(cves=session.result.cves)
+		try: r.cve = ResultCveModel(
+			cves=session.result.cves,
+			cve_data=session.result.cve_data,
+			host_cpes=session.result.host_cpes,
+			host_cpe_ports=[HostCpePortsModel(host=k[0], cpe=k[1], ports=session.result.host_cpe_ports[k]) for k in session.result.host_cpe_ports.keys()]
+		)
 		except: pass
 
 	return r

--- a/backend/app/schemes/result.py
+++ b/backend/app/schemes/result.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, Json
 
@@ -12,9 +12,17 @@ class ResultNmapModel(BaseModel):
 	result: str = Field(default="", description="Nmapの実行結果(XML形式)")
 	stderr: str = Field(default="", description="Nmapの標準エラー出力(stderr, プレーンテキスト)")
 
+class HostCpePortsModel(BaseModel):
+	host: str
+	cpe: str
+	ports: set[str]
+
 class ResultCveModel(BaseModel):
 	"""CVE検索の結果"""
 	cves: dict[str, Json] = Field(default=dict(), description="CVE情報のJSON。キーはCPE文字列で値はCVE情報")
+	cve_data: Optional[list[Any]] = Field(default=None, description="CVEデータ")
+	host_cpes: Optional[dict[str, set[str]]] = Field(default=None, description="ホストとそのホストが持つCPE文字列")
+	host_cpe_ports: Optional[list[HostCpePortsModel]] = Field(default=None, description="CVEデータ")
 
 class ResultWebSearchModel(BaseModel):
 	"""Web検索の結果"""

--- a/backend/app/session.py
+++ b/backend/app/session.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from datetime import datetime
 from pathlib import Path
-from typing import final
+from typing import Any, final
 from uuid import UUID, uuid4
 
 from log import Logger
@@ -22,6 +22,9 @@ class Result():
 	# CVE
 	cves: dict[str, str] = dict()
 	"""キー: CPE, 値: CVE情報のJSON"""
+	cve_data: list[Any] = []
+	host_cpes: dict[str, set[str]] = dict()
+	host_cpe_ports: dict[tuple[str, str], set[str]] = dict()
 
 	# DuckDuckGo
 	web: str = ""


### PR DESCRIPTION
`/result/show`の結果に`cve_data`, `host_cpes`, `host_cpe_ports`を追加した

* `cve_data`にはCVE情報のサブセットが格納される
* `host_cpes`には見つかったホストと、そのホスト上にあるプラットフォームのCPE文字列が格納される
* `host_cpe_ports`には「ホストとCPEの組」に対応するプロトコルとポート番号の配列が格納される

例:
```jsonc
{
  "subfinder": { /* ... */ },
  "nmap": { /* ... */ },
  "cve": {
    "cves": {
      "cpe:/a:apache:http_server": [ /* ... */ ],
      /* ... */
    },
    /* ここから追加部分↓ */
    "cve_data": [
      {
        "cpe": "cpe:/o:microsoft:windows",
        "id": "CVE-2021-26622",
        "published": "2022-03-25T19:15:00",
        "published_str": "2022-03-25T19:15:00",
        "cvss": 10,
        "cvss3": 10,
        "summary": "An remote code execution vulnerability due to SSTI vulnerability and insufficient file name parameter validation was discovered in Genian NAC. Remote attackers are able to execute arbitrary malicious code with SYSTEM privileges on all connected nodes in NAC through this vulnerability.",
        "gemini": "**脆弱性評価**\n\n**脆弱性:** Genian NAC における SSTI 脆弱性とファイル名パラメータの検証不備によるリモートコード実行の脆弱性\n\n**影響:**\n\n* リモートの攻撃者は、NAC に接続されたすべてのノード上で SYSTEM 権限で任意の悪意のあるコードを実行可能\n* この脆弱性は、SSTI の脆弱性とファイル名パラメータの検証不備が組み合わさって発生する\n\n**推奨対策:**\n\n* 最新バージョンの Genian NAC にアップデートする\n* ファイル名パラメータの検証を強化する\n* SSTI 攻撃を防ぐ対策を実施する\n* ネットワークの監視と、不正アクティビティの検出メカニズムを強化する"
      },
      {
        "cpe": "cpe:/a:apache:http_server",
        "id": "CVE-1999-1237",
        "published": "1999-06-06T04:00:00",
        "published_str": "1999-06-06T04:00:00",
        "cvss": 10,
        "cvss3": -1,
        "summary": "Multiple buffer overflows in smbvalid/smbval SMB authentication library, as used in Apache::AuthenSmb and possibly other modules, allows remote attackers to execute arbitrary commands via (1) a long username, (2) a long password, and (3) other unspecified methods."
      },
    ],
    "host_cpes": {
      "133.125.39.70": [
        "cpe:/a:postgresql:postgresql",
        "cpe:/o:microsoft:windows",
        "cpe:/a:microsoft:internet_information_services:10.0"
      ],
      "sangi.ac.jp": [
        "cpe:/a:apache:http_server"
      ],
      "dousoukai.sangi.ac.jp": [],
      "www.sangi.ac.jp": [
        "cpe:/a:apache:http_server"
      ]
    },
    "host_cpe_ports": [
      {
        "host": "133.125.39.70",
        "cpe": "cpe:/o:microsoft:windows",
        "ports": [
          "tcp/3389",
          "tcp/5432",
          "tcp/443",
          "tcp/139",
          "tcp/445",
          "tcp/135",
          "tcp/25"
        ]
      },
      {
        "host": "133.125.39.70",
        "cpe": "cpe:/a:microsoft:internet_information_services:10.0",
        "ports": [
          "tcp/3389",
          "tcp/5432",
          "tcp/443",
          "tcp/139",
          "tcp/445",
          "tcp/135",
          "tcp/25"
        ]
      },
      {
        "host": "133.125.39.70",
        "cpe": "cpe:/a:postgresql:postgresql",
        "ports": [
          "tcp/5432",
          "tcp/445",
          "tcp/139",
          "tcp/135",
          "tcp/25"
        ]
      },
      {
        "host": "sangi.ac.jp",
        "cpe": "cpe:/a:apache:http_server",
        "ports": [
          "tcp/80",
          "tcp/443"
        ]
      },
      {
        "host": "www.sangi.ac.jp",
        "cpe": "cpe:/a:apache:http_server",
        "ports": [
          "tcp/80",
          "tcp/443"
        ]
      }
    ]
  },
  /* ... */
}
```